### PR TITLE
Update cache control settings in background image fetching: Reduced c…

### DIFF
--- a/app/api/background/route.ts
+++ b/app/api/background/route.ts
@@ -6,15 +6,15 @@ export async function GET() {
   try {
     // 添加缓存控制头
     const headers = new Headers({
-      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=3600",
+      "Cache-Control": "public, s-maxage=60, stale-while-revalidate=60",
     });
 
     const response = await fetch(
       "https://api.bimg.cc/random?w=1920&h=1080&mkt=zh-CN",
       {
-        next: { revalidate: 3600 },
+        next: { revalidate: 60 },
         headers: {
-          "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=3600",
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=60",
         },
         redirect: "follow",
       }


### PR DESCRIPTION
…ache duration in route.ts from 3600 to 60 seconds for both response headers and revalidation, optimizing performance and ensuring more frequent updates of background images.